### PR TITLE
feat: 修复node>=16 情况下，arch返回arm64导致的 tar.gz 下载不到资源维问题

### DIFF
--- a/lib/installer/installer.js
+++ b/lib/installer/installer.js
@@ -64,7 +64,7 @@ class Installer {
 
     let platform = process.env.MOCK_OS_PLATFORM || os.platform();
     if (platform === 'win32') platform = 'win';
-    const arch = os.arch() === 'x64' ? 'x64' : 'x86';
+    const arch = ['x64', 'arm64'].includes(os.arch()) ? 'x64' : 'x86';
     const shaUrl = `${distUrl}/v${version}/SHASUMS256.txt`;
     const tgzUrl = `${distUrl}/v${version}/${name}-v${version}-${platform}-${arch}.tar.gz`;
 


### PR DESCRIPTION
#19 