### PR TITLE
feat: support win32 platform.

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,52 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [12, 14, 16]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+    - name: Checkout Git Source
+      uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install Dependencies
+      run: npm i -g npminstall@5 && npminstall
+
+    - name: Continuous Integration
+      shell: bash
+      run: |
+        if [[ "$RUNNER_OS" == "Windows" ]]; then
+          npm run test:win32;
+        else
+          npm run ci;
+        fi
+
+    - name: Code Coverage
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/lib/installer/installer.js
+++ b/lib/installer/installer.js
@@ -9,9 +9,14 @@ const ProgressBar = require('progress');
 const crypto = require('crypto');
 const zlib = require('zlib');
 const tar = require('tar');
+const child_process = require('child_process');
+
 const mkdirp = require('mkdirp');
+const rimraf = require('rimraf');
 const debug = require('debug')('nodeinstall');
 const assert = require('assert');
+const AdmZip = require('adm-zip');
+
 const request = require('../request');
 const cache = require('../cache');
 const getLocalNodeVersion = require('../version').getLocalNodeVersion;
@@ -66,23 +71,38 @@ class Installer {
     if (platform === 'win32') platform = 'win';
     const arch = os.arch() === 'x64' ? 'x64' : 'x86';
     const shaUrl = `${distUrl}/v${version}/SHASUMS256.txt`;
-    const tgzUrl = `${distUrl}/v${version}/${name}-v${version}-${platform}-${arch}.tar.gz`;
+    const pkgUrl = `${distUrl}/v${version}/${name}-v${version}-${platform}-${arch}.${platform === 'win' ? 'zip' : 'tar.gz'}`;
 
     // use cache or not
     const cacheStrategy = cache.getStrategy();
     debug('cacheStrategy, %j', cacheStrategy);
-    const targetName = path.basename(urlparse(tgzUrl).pathname);
+    const targetName = path.basename(urlparse(pkgUrl).pathname);
     const targetFile = path.join(cacheStrategy.cache, targetName);
 
     try {
       // download tarball if cache is disabled or cache file is not exist,
       // otherwise use cache
       if (cacheStrategy.disable || !fs.existsSync(targetFile)) {
-        yield downloadTgz(tgzUrl, shaUrl, targetFile);
+        yield downloadFile(pkgUrl, shaUrl, targetFile);
       }
 
-      // extract tarball to $cwd/node_modules
-      yield extract(targetFile, nodeDir);
+      // extract tarball/zip to $cwd/node_modules
+      if (platform === 'win') {
+        const entryDir = path.basename(targetFile, '.zip');
+        const destDir = path.resolve(nodeLinkDir, entryDir);
+        rimraf.sync(destDir);
+
+        try {
+          yield unzipFile(targetFile, path.dirname(destDir));
+        } catch (e) {
+          console.error('[install] extract zip error:', e);
+        }
+
+        rimraf.sync(nodeDir);
+        cpWin32(destDir, nodeDir, false);
+      } else {
+        yield extract(targetFile, nodeDir);
+      }
     } catch (err) {
       if (fs.existsSync(targetFile)) {
         fs.unlinkSync(targetFile);
@@ -91,11 +111,15 @@ class Installer {
     }
 
     mkdirp.sync(nodeLinkDir);
-    if (!fs.existsSync(nodeLink)) {
-      fs.symlinkSync(path.normalize('../node/bin/node'), nodeLink);
-    }
-    if (!fs.existsSync(npmLink)) {
-      fs.symlinkSync(path.normalize('../node/bin/npm'), npmLink);
+    if (platform === 'win') {
+      putBinaryWin32(nodeDir, nodeLinkDir);
+    } else {
+      if (!fs.existsSync(nodeLink)) {
+        fs.symlinkSync(path.normalize('../node/bin/node'), nodeLink);
+      }
+      if (!fs.existsSync(npmLink)) {
+        fs.symlinkSync(path.normalize('../node/bin/npm'), npmLink);
+      }
     }
     const packageJsonFile = path.join(nodeDir, 'package.json');
     fs.writeFileSync(packageJsonFile, JSON.stringify({
@@ -111,9 +135,9 @@ class Installer {
 
 module.exports = Installer;
 
-function* downloadTgz(tgzUrl, shaUrl, targetFile) {
-  debug('download %s to %s', tgzUrl, targetFile);
-  const ret = yield request(tgzUrl, {
+function* downloadFile(url, shaUrl, targetFile) {
+  debug('download %s to %s', url, targetFile);
+  const ret = yield request(url, {
     timeout: 20000,
     streaming: true,
     followRedirect: true,
@@ -122,7 +146,7 @@ function* downloadTgz(tgzUrl, shaUrl, targetFile) {
   const res = ret.res;
 
   if (res.statusCode !== 200) {
-    const err = new Error('GET ' + tgzUrl + ' got ' + res.statusCode);
+    const err = new Error('GET ' + url + ' got ' + res.statusCode);
     err.statusCode = res.statusCode;
     err.headers = res.headers;
     throw err;
@@ -155,6 +179,59 @@ function* verifyChecksum(shaUrl, targetFile) {
   debug('checksum success %s', refSha);
 }
 
+function unzipFile(zipFile, targetDir) {
+  if (typeof zipFile === 'string') {
+    if (!zipFile || !fs.existsSync(zipFile) || !fs.statSync(zipFile).isFile()) { throw new Error('[unzipFile] zipFile should be one existed filename!'); }
+  } else if (!Buffer.isBuffer(zipFile)) {
+    throw new Error('[unzipFile] zipFile should be buffer or filename!');
+  }
+
+  const zipInst = new AdmZip(zipFile);
+
+  if (!fs.existsSync(targetDir)) {
+    fs.mkdirSync(targetDir, { mode: '777', recursive: true });
+  } else if (!fs.statSync(targetDir).isDirectory()) {
+    throw new Error('[unzipFile] targetDir should be directory!');
+  }
+
+  return new Promise(function(resolve, reject) {
+    try {
+      zipInst.extractAllTo(targetDir, true);
+      resolve();
+    } catch (e) {
+      reject(e);
+    }
+
+  });
+}
+
+function cpWin32(source, target, keepbase = false) {
+  if (keepbase) {
+    child_process.execSync(`xcopy \"${source}\" \"${target}\" /e /c /h /r /k /o /y`);
+  } else {
+    child_process.execSync(`xcopy \"${source}\" \"${target}\" /e /c /h /i`);
+  }
+}
+
+function putBinaryWin32(nodeDir, projectBinDir) {
+  [
+    'node.exe',
+    'npm.cmd',
+    'npm',
+    'node_modules',
+  ].forEach(function(file) {
+    const source = path.resolve(nodeDir, file);
+    const target = path.resolve(projectBinDir, file);
+    if (fs.existsSync(target)) rimraf.sync(target);
+
+    if (!fs.statSync(source).isDirectory()) {
+      cpWin32(source, projectBinDir, true);
+    } else {
+      cpWin32(source, target, false);
+    }
+  });
+}
+
 function extract(targetFile, nodeDir) {
   return new Promise((resolve, reject) => {
     const gunzip = zlib.createGunzip();
@@ -170,8 +247,8 @@ function writeFile(res, targetFile) {
   mkdirp.sync(path.dirname(targetFile));
   return new Promise(function(resolve, reject) {
     const ws = fs.createWriteStream(targetFile)
-    .on('error', reject)
-    .on('finish', resolve);
+      .on('error', reject)
+      .on('finish', resolve);
     showProgress(res);
     res.on('error', reject);
     res.pipe(ws);

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.6",
   "description": "",
   "dependencies": {
+    "adm-zip": "^0.5.9",
     "bytes": "^2.5.0",
     "co": "^4.6.0",
     "commander": "^2.9.0",
@@ -19,6 +20,7 @@
   "devDependencies": {
     "autod": "^2.8.0",
     "coffee": "^3.3.1",
+    "cross-env": "^7.0.3",
     "egg-bin": "^1.10.3",
     "egg-ci": "^1.6.0",
     "eslint": "^3.19.0",
@@ -38,6 +40,7 @@
     "contributor": "git-contributor",
     "start": "node index.js",
     "dev": "egg-bin dev",
+    "test:win32": "cross-env TESTS=test-win32/*.js egg-bin test",
     "test": "npm run lint && egg-bin test",
     "test-china": "NODEINSTALL_CHINA=true egg-bin test",
     "cov": "egg-bin cov",

--- a/test-win32/fixtures/install-alinode/package.json
+++ b/test-win32/fixtures/install-alinode/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "alinode"
+}

--- a/test-win32/fixtures/install-node/package.json
+++ b/test-win32/fixtures/install-node/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "install-node"
+}

--- a/test-win32/fixtures/install-nsolid/package.json
+++ b/test-win32/fixtures/install-nsolid/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "install-nsolid"
+}

--- a/test-win32/install_node_win32.test.js
+++ b/test-win32/install_node_win32.test.js
@@ -1,0 +1,340 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const rimraf = require('rimraf');
+const coffee = require('coffee');
+const execSync = require('child_process').execSync;
+
+const tnpm = path.join(__dirname, '..', 'bin', 'tnpm.js');
+const fixtures = path.join(__dirname, 'fixtures');
+const nodeinstall = path.join(__dirname, '../bin/nodeinstall');
+
+function _trimEOL(str) {
+  return str.replace('\r\n', '').replace('\n', '');
+}
+
+// specify corresponding node version and npm-cli version for env for npm.cmd
+function getEnv(nodeBinPath) {
+  return {
+    NODE_EXE: nodeBinPath,
+    NPM_PREFIX_NPM_CLI_JS: path.join(path.dirname(nodeBinPath), 'node_modules/npm/bin/npm-cli.js'),
+  };
+}
+
+describe('test/install_node_win32.test.js', function() {
+  let cwd = path.join(fixtures, 'install-node');
+  beforeEach(function() {
+    if (cwd) {
+      rimraf.sync(path.join(cwd, 'node_modules'));
+    }
+  });
+  afterEach(function() {
+    if (cwd) {
+      rimraf.sync(path.join(cwd, 'node_modules'));
+    }
+  });
+
+  it('should install node', function* () {
+    cwd = path.join(fixtures, 'install-node');
+    // zip file for windows provided started from nodejs 6.2.2
+    yield coffee
+      .fork(nodeinstall, [ '6.2.2' ], { cwd })
+      .debug()
+      .expect('code', 0)
+      .end();
+
+    assert(fs.existsSync(path.join(cwd, 'node_modules')));
+    const nodeBinPath = path.join(cwd, 'node_modules/.bin/node.exe');
+    const npmBinPath = path.join(cwd, 'node_modules/.bin/npm.cmd');
+    const nodeDir = path.join(cwd, 'node_modules/node');
+    assert(fs.existsSync(nodeBinPath));
+    assert(fs.existsSync(path.join(cwd, 'node_modules/.bin/npm.cmd')));
+    assert(fs.existsSync(nodeDir));
+
+    assert(_trimEOL(execSync(`${nodeBinPath} -v`).toString()) === 'v6.2.2');
+    assert(_trimEOL(execSync(`\"${npmBinPath}\" -v`, { env: getEnv(nodeBinPath) }).toString()) === '3.9.5');
+  });
+
+  it('should install noderc', function* () {
+    cwd = path.join(fixtures, 'install-node');
+    yield coffee
+      .fork(nodeinstall, [ '--install-noderc', '6.9.2-rc.1' ], { cwd })
+      .debug()
+      .expect('code', 0)
+      .end();
+
+    assert(fs.existsSync(path.join(cwd, 'node_modules')));
+    const nodeBinPath = path.join(cwd, 'node_modules/.bin/node.exe');
+    // const npmBinPath = path.join(cwd, 'node_modules/.bin/npm.cmd');
+    const nodeDir = path.join(cwd, 'node_modules/node');
+    assert(fs.existsSync(nodeBinPath));
+    assert(fs.existsSync(path.join(cwd, 'node_modules/.bin/npm')));
+    assert(fs.existsSync(nodeDir));
+    assert(_trimEOL(execSync(`${nodeBinPath} -v`).toString()) === 'v6.9.2-rc.1');
+  });
+
+  it('should install node nightly', function* () {
+    cwd = path.join(fixtures, 'install-node');
+    yield coffee
+      .fork(nodeinstall, [ '--install-nightly' ], { cwd })
+      .debug()
+      .expect('code', 0)
+      .end();
+
+    assert(fs.existsSync(path.join(cwd, 'node_modules')));
+    const nodeBinPath = path.join(cwd, 'node_modules/.bin/node.exe');
+    // const npmBinPath = path.join(cwd, 'node_modules/.bin/npm.cmd');
+    const nodeDir = path.join(cwd, 'node_modules/node');
+    assert(fs.existsSync(nodeBinPath));
+    assert(fs.existsSync(path.join(cwd, 'node_modules/.bin/npm.cmd')));
+    assert(fs.existsSync(nodeDir));
+
+    assert(fs.existsSync(path.join(nodeDir, 'node_modules/npm/bin/npm-cli.js')));
+
+    assert(/v\d+.\d+.\d+-nightly[a-z0-9]{18}/.test(
+      _trimEOL(execSync(`${nodeBinPath} -v`).toString())
+    ));
+  });
+
+  it.skip('should work with rc version install-node=0.10.41-rc.1', function(done) {
+    cwd = path.join(fixtures, 'node-0.10');
+
+    coffee
+    .fork(tnpm, [ 'install', '--install-noderc=0.10.41-rc.1' ], { cwd })
+    .debug()
+    .expect('code', 0)
+    // .expect('stdout', /node@0\.10\.41-rc\.1 installed/)
+    .end(function(err) {
+      assert.ifError(err);
+      // package.json should exists
+      const jsonFile = path.join(cwd, 'node_modules', 'node', 'package.json');
+      JSON.parse(fs.readFileSync(jsonFile)).name.should.equal('node');
+      done();
+    });
+  });
+
+  it.skip('should work with install-node=4.3.0', function(done) {
+    cwd = path.join(fixtures, 'node-4');
+
+    coffee
+    .fork(tnpm, [ 'install', '--install-node=4.3.0' ], { cwd })
+    .debug()
+    .expect('code', 0)
+    .expect('stdout', /node@\d+\.\d+\.\d+ installed/)
+    .end(function(err) {
+      assert.ifError(err);
+      // package.json should exists
+      const jsonFile = path.join(cwd, 'node_modules', 'node', 'package.json');
+      JSON.parse(fs.readFileSync(jsonFile)).name.should.equal('node');
+      done();
+    });
+  });
+
+  it.skip('should work with install-node=4', function(done) {
+    cwd = path.join(fixtures, 'node-4');
+
+    coffee
+    .fork(tnpm, [ 'install', '--install-node=4' ], { cwd })
+    .debug()
+    .expect('code', 0)
+    .expect('stdout', /node@\d+\.\d+\.\d+ installed/)
+    .end(function(err) {
+      assert.ifError(err);
+      // package.json should exists
+      const jsonFile = path.join(cwd, 'node_modules', 'node', 'package.json');
+      JSON.parse(fs.readFileSync(jsonFile)).name.should.equal('node');
+      // npm link exists on node_modules/.bin/npm
+      if (process.platform === 'win32') {
+        fs.existsSync(path.join(cwd, 'node_modules', '.bin', 'npm.cmd')).should.equal(true);
+      } else {
+        fs.existsSync(path.join(cwd, 'node_modules', '.bin', 'npm')).should.equal(true);
+      }
+      done();
+    });
+  });
+
+  it.skip('should work with install-node=5.10', function(done) {
+    cwd = path.join(fixtures, 'node-4');
+
+    coffee
+    .fork(tnpm, [ 'ii', '--install-node=5.10' ], { cwd })
+    .debug()
+    .expect('code', 0)
+    .expect('stdout', /node@\d+\.\d+\.\d+ installed/)
+    .end(function(err) {
+      assert.ifError(err);
+      // package.json should exists
+      const jsonFile = path.join(cwd, 'node_modules', 'node', 'package.json');
+      JSON.parse(fs.readFileSync(jsonFile)).name.should.equal('node');
+      done();
+    });
+  });
+
+  it.skip('should work with install-alinode=1.4.0', function(done) {
+    cwd = path.join(fixtures, 'node-4');
+
+    coffee
+    .fork(tnpm, [ 'install', '--install-alinode=1.4.0' ], { cwd })
+    .debug()
+    .expect('code', 0)
+    .expect('stdout', /node@\d+\.\d+\.\d+ \/ alinode@\d+\.\d+\.\d+ installed/)
+    .end(function(err) {
+      assert.ifError(err);
+      // package.json should exists
+      const jsonFile = path.join(cwd, 'node_modules', 'node', 'package.json');
+      JSON.parse(fs.readFileSync(jsonFile)).name.should.equal('alinode');
+      done();
+    });
+  });
+
+  it.skip('should work with install-alinode=1', function(done) {
+    cwd = path.join(fixtures, 'node-4');
+
+    coffee
+    .fork(tnpm, [ 'ii', '--install-alinode=1' ], { cwd })
+    .debug()
+    .expect('code', 0)
+    .expect('stdout', /node@\d+\.\d+\.\d+ \/ alinode@\d+\.\d+\.\d+ installed/)
+    .end(function(err) {
+      assert.ifError(err);
+      // package.json should exists
+      const jsonFile = path.join(cwd, 'node_modules', 'node', 'package.json');
+      JSON.parse(fs.readFileSync(jsonFile)).name.should.equal('alinode');
+      done();
+    });
+  });
+
+  it.skip('should install alinode-iojs: iojs-1', function(done) {
+    cwd = path.join(fixtures, 'iojs-1');
+
+    coffee
+    .fork(tnpm, [ 'install' ], { cwd })
+    .debug()
+    .expect('code', 0)
+    .end(done);
+  });
+
+  it.skip('should install alinode-iojs: iojs-2', function(done) {
+    cwd = path.join(fixtures, 'iojs-2');
+
+    coffee
+    .fork(tnpm, [ 'install', '--production' ], { cwd })
+    .debug()
+    .expect('code', 0)
+    .end(done);
+  });
+
+  it.skip('should install alinode-iojs: iojs-3', function(done) {
+    cwd = path.join(fixtures, 'iojs-3');
+
+    coffee
+    .fork(tnpm, [ 'install' ], { cwd })
+    .debug()
+    .expect('code', 0)
+    .end(done);
+  });
+
+  it.skip('should install install-node: node-4.1.1 show SECURITY tips', function(done) {
+    cwd = path.join(fixtures, 'node-4.1.1-security-tips');
+
+    coffee
+    .fork(tnpm, [ 'install' ], { cwd })
+    .debug()
+    .expect('code', 0)
+    .end(done);
+  });
+
+  it.skip('should install install-node: node-4', function(done) {
+    cwd = path.join(fixtures, 'node-4');
+
+    coffee
+    .fork(tnpm, [ 'install' ], { cwd })
+    .debug()
+    .expect('code', 0)
+    .end(done);
+  });
+
+  it.skip('should install alinode: alinode-1', function(done) {
+    cwd = path.join(fixtures, 'alinode-1');
+
+    coffee
+    .fork(tnpm, [ 'install' ], { cwd })
+    .debug()
+    .expect('code', 0)
+    .end(done);
+  });
+
+  it.skip('should install alinode: alinode-0.12.7', function(done) {
+    cwd = path.join(fixtures, 'alinode-0.12.7');
+
+    coffee
+    .fork(tnpm, [ 'install' ], { cwd })
+    .debug()
+    .expect('code', 0)
+    .end(done);
+  });
+
+  it.skip('should install alinode-iojs 2.5 from within a sub dir', function(done) {
+    cwd = path.join(fixtures, 'from-within-sub-dir', 'subdir');
+
+    coffee
+    .fork(tnpm, [ 'install' ], { cwd })
+    .debug()
+    .expect('code', 0)
+    .end(done);
+  });
+
+  // TODO: bin/npminstall 需要加判断？
+  it.skip('should fail with --global option enabled', function(done) {
+    cwd = path.join(fixtures, 'with-global-option');
+
+    coffee
+    .fork(tnpm, [ 'install', '--global', '--loglevel=http' ], { cwd })
+    .debug()
+    .notExpect('code', 0)
+    .end(done);
+  });
+
+  it.skip('should install alinode-iojs wrong version', function(done) {
+    cwd = path.join(fixtures, 'wrong_version');
+
+    coffee
+    .fork(tnpm, [ 'install' ], { cwd })
+    .debug()
+    .notExpect('code', 0)
+    .end(done);
+  });
+
+  it.skip('should install alinode-iojs not exists version', function(done) {
+    cwd = path.join(fixtures, 'not_exists_version');
+
+    coffee
+    .fork(tnpm, [ 'install' ], { cwd })
+    .debug()
+    .notExpect('code', 0)
+    .end(done);
+  });
+
+  it.skip('should install install-node not exists iojs version', function(done) {
+    cwd = path.join(fixtures, 'not_exist_iojs_version');
+
+    coffee
+    .fork(tnpm, [ 'install' ], { cwd })
+    .debug()
+    .notExpect('code', 0)
+    .end(done);
+  });
+
+  it.skip('should install alinode not exists version', function(done) {
+    cwd = path.join(fixtures, 'not_exists_alinode_version');
+
+    coffee
+    .fork(tnpm, [ 'install' ], { cwd })
+    .debug()
+    .notExpect('code', 0)
+    .end(done);
+  });
+
+});


### PR DESCRIPTION
CI on all platforms (node >= 12): https://github.com/richardo2016-forks/nodeinstall/actions/runs/3532566091

I tried to use node 4, 6, 7, but it's infrustrating to pick specific npminstall version to make dependencies installed correctly. Since most develoers use node >= 8 and LTS version is node v14.x, I configured node 12, 14, 16 on CI.

I don't modify the nodejs version in `.travis.yml` and `appveyor.yml`, but, I think it's better to upgrade them or specify the version of `npminstall` on CI to fix error on those CI platforms. Or, maybe you could github actions from now.