### PR TITLE
feat: support arm64 for apple silicon.

### DIFF
--- a/lib/installer/installer.js
+++ b/lib/installer/installer.js
@@ -64,7 +64,7 @@ class Installer {
 
     let platform = process.env.MOCK_OS_PLATFORM || os.platform();
     if (platform === 'win32') platform = 'win';
-    const arch = os.arch() === 'x64' ? 'x64' : 'x86';
+    const arch = ['x64', 'arm64'].includes(os.arch()) ? 'x64' : 'x86';
     const shaUrl = `${distUrl}/v${version}/SHASUMS256.txt`;
     const tgzUrl = `${distUrl}/v${version}/${name}-v${version}-${platform}-${arch}.tar.gz`;
 

--- a/lib/installer/installer.js
+++ b/lib/installer/installer.js
@@ -64,7 +64,7 @@ class Installer {
 
     let platform = process.env.MOCK_OS_PLATFORM || os.platform();
     if (platform === 'win32') platform = 'win';
-    const arch = ['x64', 'arm64'].includes(os.arch()) ? 'x64' : 'x86';
+    const arch = os.arch() === 'ia32' ? 'x86' : os.arch();
     const shaUrl = `${distUrl}/v${version}/SHASUMS256.txt`;
     const tgzUrl = `${distUrl}/v${version}/${name}-v${version}-${platform}-${arch}.tar.gz`;
 


### PR DESCRIPTION
This PR finish #20, there's no recent update in it so I do some changes and take another one.

Installer can get correct download url of tar.gz with arm64 binary on Apple M1. , which nodeinstall were expected to support.

Further more, it's not final status of the logic, because some special arch not fully supported here (`armv71`, `s390`, etc). But, we don't need support them now, the environment nodeinstall work on is limited. These changes would make nodeinstall work well on those arches: `x64`, `x86`(ia32) and `arm64`.