### PR TITLE
feat: use spread operator instead of Object.assign()

### DIFF
--- a/lib/installer/alinode_installer.js
+++ b/lib/installer/alinode_installer.js
@@ -7,7 +7,10 @@ const Installer = require('./installer');
 class AlinodeInstaller extends Installer {
 
   constructor(options) {
-    super(Object.assign({}, options, { name: 'alinode' }));
+    super({
+      ...options,
+      name: 'alinode',
+    });
   }
 
   async getVersion() {

--- a/lib/installer/node_installer.js
+++ b/lib/installer/node_installer.js
@@ -6,8 +6,10 @@ const Installer = require('./installer');
 class NodeInstaller extends Installer {
 
   constructor(options) {
-    options = Object.assign({}, options, { name: 'node' });
-    super(options);
+    super({
+      ...options,
+      name: 'node',
+    });
   }
 
   async getVersion() {

--- a/lib/installer/nsolid_installer.js
+++ b/lib/installer/nsolid_installer.js
@@ -8,7 +8,10 @@ const Installer = require('./installer');
 class NSolidInstaller extends Installer {
 
   constructor(options) {
-    super(Object.assign({}, options, { name: 'nsolid' }));
+    super({
+      ...options,
+      name: 'nsolid',
+    });
   }
 
   async getVersion() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the constructors of the `AlinodeInstaller`, `NodeInstaller`, and `NSolidInstaller` classes for improved readability and modern syntax.
  
- **Bug Fixes**
	- No functional changes; existing methods like `getVersion` and `install` remain intact and operational.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->